### PR TITLE
merged changes:

### DIFF
--- a/src/android/chcp.gradle
+++ b/src/android/chcp.gradle
@@ -11,6 +11,6 @@ cdvPluginPostBuildExtras.add({
     dependencies {
         compile 'com.fasterxml.jackson.core:jackson-core:2.4.4'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.4.4'
-        compile 'de.greenrobot:eventbus:3.0.0-beta1'
+        compile 'org.greenrobot:eventbus:3.0.0'
     }
 });

--- a/src/android/src/com/nordnetab/chcp/main/config/ApplicationConfig.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/ApplicationConfig.java
@@ -83,7 +83,7 @@ public class ApplicationConfig {
                 returnString.append(line);
             }
         } catch (Exception e) {
-            Log.d("CHCP", "Failed to read chcp.json from assets", e);
+            Log.d("CHCP", "Failed to read chcp.json from assets");
         } finally {
             try {
                 if (reader != null) {

--- a/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfig.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfig.java
@@ -3,6 +3,8 @@ package com.nordnetab.chcp.main.config;
 import android.content.Context;
 import android.text.TextUtils;
 
+import com.nordnetab.chcp.main.network.FileDownloader;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -16,11 +18,19 @@ public class ChcpXmlConfig {
     private String configUrl;
     private boolean allowUpdatesAutoDownload;
     private boolean allowUpdatesAutoInstall;
+    private boolean allowAutoRedirectionToLocalStorageIndexPage;
+    private boolean allowUseOfInitialVersionFromAssets;
+    private boolean requireFreshInstallAfterAppVersionUpdate;
+    private String assetsRemoteZipUrl;
 
     private ChcpXmlConfig() {
         configUrl = "";
         allowUpdatesAutoDownload = true;
         allowUpdatesAutoInstall = true;
+        allowAutoRedirectionToLocalStorageIndexPage = true;
+        allowUseOfInitialVersionFromAssets = true;
+        requireFreshInstallAfterAppVersionUpdate = true;
+        assetsRemoteZipUrl = "";
     }
 
     /**
@@ -81,6 +91,102 @@ public class ChcpXmlConfig {
     }
 
     /**
+     * Setter for the flag if the initial version should be taken from the assets folder.
+     *
+     * @param isAllowed set to <code>true</code> to allow the usage of the initial version from the assets folder.
+     */
+    public void allowUseOfInitialVersionFromAssets(boolean isAllowed) {
+        allowUseOfInitialVersionFromAssets = isAllowed;
+    }
+
+    /**
+     * Getter for the flag if use of initial version from assets folder is allowed.
+     * By default it is on, but you can disable it from JavaScript.
+     *
+     * @return <code>true</code> if the initial version should be taken from the assets folder, <code>false</code> - otherwise.
+     */
+    public boolean isUseOfInitialVersionFromAssetsAllowed() {
+        return allowUseOfInitialVersionFromAssets;
+    }
+
+    /**
+     * Setter for the flag if auto redirect to the local storage index page is allowed.
+     *
+     * @param isAllowed set to <code>true</code> to allow automatic redirection to the local storage index page.
+     */
+    public void allowAutoRedirectToLocalStorageIndexPage(boolean isAllowed) {
+        allowAutoRedirectionToLocalStorageIndexPage = isAllowed;
+    }
+
+    /**
+     * Getter for the flag if automatic redirection to the local storage index page is allowed.
+     * By default it is on, but you can disable it from JavaScript.
+     *
+     * @return <code>true</code> if automatic redirection to the local storage index page, <code>false</code> - otherwise.
+     */
+    public boolean isAutoRedirectionToLocalStorageIndexPageAllowed() {
+        return allowAutoRedirectionToLocalStorageIndexPage;
+    }
+
+    /**
+     * Setter for the flag if a fresh install of the web-app code is required after the app is updated.
+     * When set to <code>false</code> this is useful for SDKs.
+     *
+     * @param isRequired set to <code>true</code> to require a fresh install of the web-app code after the app is updated.
+     */
+    public void setRequireFreshInstallAfterAppUpdate(boolean isRequired) {
+        requireFreshInstallAfterAppVersionUpdate = isRequired;
+    }
+
+    /**
+     * Getter for the flag if a fresh install of the web-app code is required after the app is updated.
+     * By default it is on, but you can disable it from JavaScript.
+     *
+     * @return <code>true</code> to require a fresh install of the web-app code after the app is updated, <code>false</code> - otherwise.
+     */
+    public boolean isFreshInstallAfterAppUpdateRequired() {
+        return requireFreshInstallAfterAppVersionUpdate;
+    }
+
+    /**
+     * Setter for the file download concurrency.
+     *
+     * @param value the number of concurrent file downloads.
+     */
+    public void setFileDownloadConcurrency(int value) {
+        FileDownloader.setConcurrencyLevel(value);
+    }
+
+    /**
+     * Getter for the file download concurrency.
+     * By default it is 1, but you can change it from JavaScript.
+     *
+     * @return the number of files that will be downloaded concurrently during an update fetch.
+     */
+    public int getFileDownloadConcurrency() {
+        return FileDownloader.getConcurrencyLevel();
+    }
+
+    /**
+     * Setter for the assets remote ZIP file.
+     *
+     * @param value the remote URL of a ZIP that includes the assets.
+     */
+    public void setAssetsRemoteZipUrl(String value) {
+        assetsRemoteZipUrl = value;
+    }
+
+    /**
+     * Getter for the remote assets ZIP file.
+     * By default it is an empty string, but you can change it from JavaScript.
+     *
+     * @return the remote URL of the ZIP file that includes that assets.
+     */
+    public String getAssetsRemoteZipUrl() {
+        return assetsRemoteZipUrl;
+    }
+
+    /**
      * Load plugins specific preferences from Cordova's config.xml.
      *
      * @param context current context of the activity
@@ -115,6 +221,26 @@ public class ChcpXmlConfig {
 
         if (jsOptions.has(XmlTags.AUTO_DOWNLOAD_TAG)) {
             allowUpdatesAutoDownload(jsOptions.getBoolean(XmlTags.AUTO_DOWNLOAD_TAG));
+        }
+
+        if (jsOptions.has(XmlTags.USE_INITIAL_VERSION_FROM_ASSETS_TAG)) {
+            allowUseOfInitialVersionFromAssets(jsOptions.getBoolean(XmlTags.USE_INITIAL_VERSION_FROM_ASSETS_TAG));
+        }
+
+        if (jsOptions.has(XmlTags.AUTO_REDIRECT_TO_LOCAL_STORAGE_INDEX_PAGE_TAG)) {
+            allowAutoRedirectToLocalStorageIndexPage(jsOptions.getBoolean(XmlTags.AUTO_REDIRECT_TO_LOCAL_STORAGE_INDEX_PAGE_TAG));
+        }
+
+        if (jsOptions.has(XmlTags.REQUIRE_FRESH_INSTALL_AFTER_APP_UPDATE_TAG)) {
+            setRequireFreshInstallAfterAppUpdate(jsOptions.getBoolean(XmlTags.REQUIRE_FRESH_INSTALL_AFTER_APP_UPDATE_TAG));
+        }
+
+        if (jsOptions.has(XmlTags.FILE_DOWNLOAD_CONCURRENCY_TAG)) {
+            setFileDownloadConcurrency(jsOptions.getInt(XmlTags.FILE_DOWNLOAD_CONCURRENCY_TAG));
+        }
+
+        if (jsOptions.has(XmlTags.ASSETS_REMOTE_ZIP_URL_TAG)) {
+            setAssetsRemoteZipUrl(jsOptions.getString(XmlTags.ASSETS_REMOTE_ZIP_URL_TAG));
         }
     }
 }

--- a/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfigParser.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/ChcpXmlConfigParser.java
@@ -1,6 +1,7 @@
 package com.nordnetab.chcp.main.config;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import org.apache.cordova.ConfigXmlParser;
 import org.xmlpull.v1.XmlPullParser;
@@ -69,6 +70,37 @@ class ChcpXmlConfigParser extends ConfigXmlParser {
         // parse auto installation preference
         if (name.equals(XmlTags.AUTO_INSTALLATION_TAG)) {
             processAutoInstallationBlock(xml);
+            return;
+        }
+
+        // parse use initial version from assets preference
+        if (name.equals(XmlTags.USE_INITIAL_VERSION_FROM_ASSETS_TAG)) {
+            processUseInitialVersionFromAssetsBlock(xml);
+            return;
+        }
+
+        // parse auto redirect to start page preference
+        if (name.equals(XmlTags.AUTO_REDIRECT_TO_LOCAL_STORAGE_INDEX_PAGE_TAG)) {
+            processAutoRedirectToLocalStorageIndexPageBlock(xml);
+            return;
+        }
+
+        // parse require fresh install after app update
+        if (name.equals(XmlTags.REQUIRE_FRESH_INSTALL_AFTER_APP_UPDATE_TAG)) {
+            processRequireFreshInstallAfterAppUpdate(xml);
+            return;
+        }
+
+        // parse require file download concurrency
+        if (name.equals(XmlTags.FILE_DOWNLOAD_CONCURRENCY_TAG)) {
+            processFileDownloadConcurrency(xml);
+            return;
+        }
+
+        // parse the assets remote zip url
+        if (name.equals(XmlTags.ASSETS_REMOTE_ZIP_URL_TAG)) {
+            processAssetsRemoteZipUrl(xml);
+            return;
         }
     }
 
@@ -86,6 +118,34 @@ class ChcpXmlConfigParser extends ConfigXmlParser {
     private void processAutoInstallationBlock(XmlPullParser xml) {
         boolean isEnabled = xml.getAttributeValue(null, XmlTags.AUTO_INSTALLATION_ENABLED_ATTRIBUTE).equals("true");
         chcpConfig.allowUpdatesAutoInstall(isEnabled);
+    }
+
+    private void processUseInitialVersionFromAssetsBlock(XmlPullParser xml) {
+        boolean isEnabled = xml.getAttributeValue(null, XmlTags.USE_INITIAL_VERSION_FROM_ASSETS_ENABLED_ATTRIBUTE).equals("true");
+        chcpConfig.allowUseOfInitialVersionFromAssets(isEnabled);
+    }
+
+    private void processAutoRedirectToLocalStorageIndexPageBlock(XmlPullParser xml) {
+        boolean isEnabled = xml.getAttributeValue(null, XmlTags.AUTO_REDIRECT_TO_LOCAL_STORAGE_INDEX_PAGE_ENABLED_ATTRIBUTE).equals("true");
+        chcpConfig.allowAutoRedirectToLocalStorageIndexPage(isEnabled);
+    }
+
+    private void processRequireFreshInstallAfterAppUpdate(XmlPullParser xml) {
+        boolean isEnabled = xml.getAttributeValue(null, XmlTags.REQUIRE_FRESH_INSTALL_AFTER_APP_UPDATE_ENABLED_ATTRIBUTE).equals("true");
+        chcpConfig.setRequireFreshInstallAfterAppUpdate(isEnabled);
+    }
+
+    private void processFileDownloadConcurrency(XmlPullParser xml) {
+        String attributeValue = xml.getAttributeValue(null, XmlTags.FILE_DOWNLOAD_CONCURRENCY_VALUE_ATTRIBUTE);
+        if(!TextUtils.isEmpty(attributeValue)) {
+            int integerValue = Integer.parseInt(attributeValue);
+            chcpConfig.setFileDownloadConcurrency(integerValue);
+        }
+    }
+
+    private void processAssetsRemoteZipUrl(XmlPullParser xml) {
+        String attributeValue = xml.getAttributeValue(null, XmlTags.ASSETSE_REMOTE_ZIP_URL_VALUE_ATTRIBUTE);
+        chcpConfig.setAssetsRemoteZipUrl(attributeValue);
     }
 
     @Override

--- a/src/android/src/com/nordnetab/chcp/main/config/ContentConfig.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/ContentConfig.java
@@ -15,7 +15,7 @@ import com.nordnetab.chcp.main.model.UpdateTime;
 public class ContentConfig {
 
     // JSON keys to parse chcp.json
-    private static class JsonKeys {
+    public static class JsonKeys {
         public static final String VERSION = "release";
         public static final String MINIMUM_NATIVE_VERSION = "min_native_interface";
         public static final String UPDATE = "update";

--- a/src/android/src/com/nordnetab/chcp/main/config/PluginInternalPreferences.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/PluginInternalPreferences.java
@@ -24,6 +24,8 @@ public class PluginInternalPreferences {
     private static final String CURRENT_RELEASE_VERSION_NAME = "current_release_version_name";
     private static final String READY_FOR_INSTALLATION_RELEASE_VERSION_NAME = "ready_for_installation_release_version_name";
 
+    private static final  String STUB_DEFAULT_RELEASE_VERSION = "default_release_version";
+
     private int appBuildVersion;
     private boolean wwwFolderInstalled;
     private String currentReleaseVersionName;
@@ -85,7 +87,7 @@ public class PluginInternalPreferences {
      * @param context application context
      * @return default plugin internal preferences
      */
-    public static PluginInternalPreferences createDefault(final Context context) {
+    public static PluginInternalPreferences createDefault(final Context context, boolean useConfigurationFromAssets) {
         final PluginInternalPreferences pluginPrefs = new PluginInternalPreferences();
         pluginPrefs.setAppBuildVersion(VersionHelper.applicationVersionCode(context));
         pluginPrefs.setWwwFolderInstalled(false);
@@ -93,10 +95,14 @@ public class PluginInternalPreferences {
         pluginPrefs.setReadyForInstallationReleaseVersionName("");
         pluginPrefs.setCurrentReleaseVersionName("");
 
-        // read app config from assets to get current release version
-        final ApplicationConfig appConfig = ApplicationConfig.configFromAssets(context);
-        if (appConfig != null) {
-            pluginPrefs.setCurrentReleaseVersionName(appConfig.getContentConfig().getReleaseVersion());
+        if(useConfigurationFromAssets) {
+            // read app config from assets to get current release version
+            final ApplicationConfig appConfig = ApplicationConfig.configFromAssets(context);
+            if (appConfig != null) {
+                pluginPrefs.setCurrentReleaseVersionName(appConfig.getContentConfig().getReleaseVersion());
+            }
+        } else {
+            pluginPrefs.setCurrentReleaseVersionName(STUB_DEFAULT_RELEASE_VERSION);
         }
 
         return pluginPrefs;

--- a/src/android/src/com/nordnetab/chcp/main/config/XmlTags.java
+++ b/src/android/src/com/nordnetab/chcp/main/config/XmlTags.java
@@ -24,4 +24,23 @@ final class XmlTags {
     public static final String AUTO_INSTALLATION_TAG = "auto-install";
     public static final String AUTO_INSTALLATION_ENABLED_ATTRIBUTE = "enabled";
 
+    // keys for auto redirect to local storage index page
+    public static final String AUTO_REDIRECT_TO_LOCAL_STORAGE_INDEX_PAGE_TAG = "auto-redirect-to-local-storage-index-page";
+    public static final String AUTO_REDIRECT_TO_LOCAL_STORAGE_INDEX_PAGE_ENABLED_ATTRIBUTE = "enabled";
+
+    // keys for use of initial version from assets
+    public static final String USE_INITIAL_VERSION_FROM_ASSETS_TAG = "use-initial-version-from-assets";
+    public static final String USE_INITIAL_VERSION_FROM_ASSETS_ENABLED_ATTRIBUTE = "enabled";
+
+    // keys for require fresh install after app update
+    public static final String REQUIRE_FRESH_INSTALL_AFTER_APP_UPDATE_TAG = "require-fresh-install-after-app-update";
+    public static final String REQUIRE_FRESH_INSTALL_AFTER_APP_UPDATE_ENABLED_ATTRIBUTE = "enabled";
+
+    // keys for file download concurrency
+    public static final String FILE_DOWNLOAD_CONCURRENCY_TAG = "file-download-concurrency";
+    public static final String FILE_DOWNLOAD_CONCURRENCY_VALUE_ATTRIBUTE = "value";
+
+    // keys for assets remote zip url
+    public static final String ASSETS_REMOTE_ZIP_URL_TAG = "assets-remote-zip-url";
+    public static final String ASSETSE_REMOTE_ZIP_URL_VALUE_ATTRIBUTE = "value";
 }

--- a/src/android/src/com/nordnetab/chcp/main/core/HotCodePushController.java
+++ b/src/android/src/com/nordnetab/chcp/main/core/HotCodePushController.java
@@ -1,0 +1,624 @@
+package com.nordnetab.chcp.main.core;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.nordnetab.chcp.main.config.ApplicationConfig;
+import com.nordnetab.chcp.main.config.ChcpXmlConfig;
+import com.nordnetab.chcp.main.config.ContentConfig;
+import com.nordnetab.chcp.main.config.PluginInternalPreferences;
+import com.nordnetab.chcp.main.events.AssetsInstallationErrorEvent;
+import com.nordnetab.chcp.main.events.AssetsInstalledEvent;
+import com.nordnetab.chcp.main.events.AutoDownloadNotAllowedErrorEvent;
+import com.nordnetab.chcp.main.events.AutoInstallNotAllowedErrorEvent;
+import com.nordnetab.chcp.main.events.NothingToInstallEvent;
+import com.nordnetab.chcp.main.events.NothingToUpdateEvent;
+import com.nordnetab.chcp.main.events.RollbackPerformedEvent;
+import com.nordnetab.chcp.main.events.UpdateDownloadErrorEvent;
+import com.nordnetab.chcp.main.events.UpdateInstallationErrorEvent;
+import com.nordnetab.chcp.main.events.UpdateInstalledEvent;
+import com.nordnetab.chcp.main.events.UpdateIsReadyToInstallEvent;
+import com.nordnetab.chcp.main.model.ChcpError;
+import com.nordnetab.chcp.main.model.PluginFilesStructure;
+import com.nordnetab.chcp.main.model.UpdateTime;
+import com.nordnetab.chcp.main.network.FileDownloader;
+import com.nordnetab.chcp.main.storage.ApplicationConfigStorage;
+import com.nordnetab.chcp.main.storage.IObjectFileStorage;
+import com.nordnetab.chcp.main.storage.IObjectPreferenceStorage;
+import com.nordnetab.chcp.main.storage.PluginInternalPreferencesStorage;
+import com.nordnetab.chcp.main.updater.UpdatesInstaller;
+import com.nordnetab.chcp.main.updater.UpdatesLoader;
+import com.nordnetab.chcp.main.utils.AssetsHelper;
+import com.nordnetab.chcp.main.utils.CleanUpHelper;
+import com.nordnetab.chcp.main.utils.VersionHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
+/**
+ * Created by orarnon on 29/02/2016.
+ */
+public class HotCodePushController {
+    private static final String WWW_FOLDER = "www";
+
+    private static HotCodePushController sInstance;
+
+    private Context applicationContext;
+
+    private IObjectFileStorage<ApplicationConfig> appConfigStorage;
+    private PluginInternalPreferences pluginInternalPrefs;
+    private IObjectPreferenceStorage<PluginInternalPreferences> pluginInternalPrefsStorage;
+    private ChcpXmlConfig chcpXmlConfig;
+    private PluginFilesStructure fileStructure;
+
+    private boolean isReady;
+
+    private final Object EVENT_LISTENERS_LOCK = new Object();
+    private List<IHotCodePushEventListener> eventListeners;
+
+    // region singleton design pattern
+
+    public static synchronized HotCodePushController getInstance(Context context) {
+        if(sInstance == null) {
+            sInstance = new HotCodePushController(context);
+        }
+
+        return sInstance;
+    }
+
+    private HotCodePushController(Context context) {
+        applicationContext = context.getApplicationContext();
+
+        eventListeners = new ArrayList<>();
+
+        parseCordovaConfigXml();
+        loadPluginInternalPreferences();
+
+        Log.d("CHCP", "Currently running release version " + pluginInternalPrefs.getCurrentReleaseVersionName());
+
+        appConfigStorage = new ApplicationConfigStorage();
+        fileStructure = new PluginFilesStructure(applicationContext, pluginInternalPrefs.getCurrentReleaseVersionName());
+
+        // clean up file system
+        if (!TextUtils.isEmpty(pluginInternalPrefs.getCurrentReleaseVersionName())) {
+            CleanUpHelper.removeReleaseFolders(applicationContext,
+                    new String[]{
+                            pluginInternalPrefs.getCurrentReleaseVersionName(),
+                            pluginInternalPrefs.getPreviousReleaseVersionName(),
+                            pluginInternalPrefs.getReadyForInstallationReleaseVersionName()
+                    }
+            );
+        }
+    }
+
+    // endregion
+
+    // region public API
+
+    public void registerListener(IHotCodePushEventListener listener) {
+        synchronized (EVENT_LISTENERS_LOCK) {
+            eventListeners.add(listener);
+
+            final EventBus eventBus = EventBus.getDefault();
+            if (!eventBus.isRegistered(this)) {
+                eventBus.register(this);
+            }
+
+            // ensure that www folder installed on external storage;
+            // if not - install it
+            isReady = isReady();
+            if (!isReady) {
+                installWwwFolder();
+            }
+        }
+    }
+
+    public void unregisterListener(IHotCodePushEventListener listener) {
+        synchronized (EVENT_LISTENERS_LOCK) {
+            eventListeners.remove(listener);
+
+            if(eventListeners.size() < 1) {
+                EventBus.getDefault().unregister(this);
+            }
+        }
+    }
+
+    /**
+     * Perform update availability check.
+     *
+     */
+    public void fetchUpdate(boolean isAutoDownload) {
+        if (!isReady) {
+            EventBus.getDefault().post(new UpdateDownloadErrorEvent(ChcpError.ASSETS_FOLDER_IN_NOT_YET_INSTALLED, null));
+            return;
+        }
+
+        if(isAutoDownload && !shouldAutoDownload()) {
+            EventBus.getDefault().post(new AutoDownloadNotAllowedErrorEvent());
+            return;
+        }
+
+        ChcpError error =
+                UpdatesLoader.downloadUpdate(applicationContext, chcpXmlConfig.getConfigUrl(), pluginInternalPrefs.getCurrentReleaseVersionName());
+        if(error != ChcpError.NONE) {
+            EventBus.getDefault().post(new UpdateDownloadErrorEvent(error, null));
+        }
+    }
+
+    /**
+     * Install update if any available.
+     *
+     */
+    public void installUpdate(boolean isAutoInstall) {
+        if (!isReady) {
+            EventBus.getDefault().post(new UpdateInstallationErrorEvent(ChcpError.ASSETS_FOLDER_IN_NOT_YET_INSTALLED, null));
+            return;
+        }
+
+        if(isAutoInstall && !shouldAutoInstall()) {
+            EventBus.getDefault().post(new AutoInstallNotAllowedErrorEvent());
+            return;
+        }
+
+        ChcpError error =
+                UpdatesInstaller.install(applicationContext, pluginInternalPrefs.getReadyForInstallationReleaseVersionName(), pluginInternalPrefs.getCurrentReleaseVersionName());
+        if(error != ChcpError.NONE) {
+            EventBus.getDefault().post(new UpdateInstallationErrorEvent(error, null));
+        }
+    }
+
+    public ChcpXmlConfig getCordovaConfigXml() {
+        return chcpXmlConfig;
+    }
+
+    public PluginInternalPreferences getPluginInternalPreferences() {
+        return pluginInternalPrefs;
+    }
+
+    public PluginFilesStructure getPluginFilesStructure() {
+        return fileStructure;
+    }
+
+
+    /**
+     * Check if plugin can perform it's duties.
+     *
+     * @return <code>true</code> - plugin is ready; otherwise - <code>false</code>
+     */
+    public boolean isReady() {
+        boolean isWwwFolderExists = isWwwFolderExists();
+        boolean isWwwFolderInstalled = pluginInternalPrefs.isWwwFolderInstalled();
+        boolean isApplicationHasBeenUpdated = chcpXmlConfig.isFreshInstallAfterAppUpdateRequired() && isApplicationHasBeenUpdated();
+
+        return isWwwFolderExists && isWwwFolderInstalled && !isApplicationHasBeenUpdated;
+    }
+
+    // endregion
+
+    // region Config loaders and initialization
+
+    /**
+     * Read hot-code-push plugin preferences from cordova config.xml
+     *
+     * @see ChcpXmlConfig
+     */
+    private void parseCordovaConfigXml() {
+        if (chcpXmlConfig != null) {
+            return;
+        }
+
+        chcpXmlConfig = ChcpXmlConfig.loadFromCordovaConfig(applicationContext);
+    }
+
+    /**
+     * Load plugin internal preferences.
+     *
+     * @see PluginInternalPreferences
+     * @see PluginInternalPreferencesStorage
+     */
+    private void loadPluginInternalPreferences() {
+        if (pluginInternalPrefs != null) {
+            return;
+        }
+
+        pluginInternalPrefsStorage = new PluginInternalPreferencesStorage(applicationContext);
+        PluginInternalPreferences config = pluginInternalPrefsStorage.loadFromPreference();
+        if ((config == null) || TextUtils.isEmpty(config.getCurrentReleaseVersionName())) {
+            config = PluginInternalPreferences.createDefault(applicationContext, chcpXmlConfig.isUseOfInitialVersionFromAssetsAllowed());
+            pluginInternalPrefsStorage.storeInPreference(config);
+        }
+        pluginInternalPrefs = config;
+    }
+
+    // endregion
+
+    // region Private API
+
+    /**
+     * Check if external version of www folder exists.
+     *
+     * @return <code>true</code> if it is in place; <code>false</code> - otherwise
+     */
+    private boolean isWwwFolderExists() {
+        return new File(fileStructure.getWwwFolder()).exists();
+    }
+
+    /**
+     * Check if application has been updated through the Google Play since the last launch.
+     *
+     * @return <code>true</code> if application was update; <code>false</code> - otherwise
+     */
+    private boolean isApplicationHasBeenUpdated() {
+        return pluginInternalPrefs.getAppBuildVersion() != VersionHelper.applicationVersionCode(applicationContext);
+    }
+
+    /**
+     * Install assets folder onto the external storage
+     */
+    private void installWwwFolder() {
+        isReady = false;
+
+        // reset www folder installed flag
+        if (pluginInternalPrefs.isWwwFolderInstalled()) {
+            pluginInternalPrefs.setWwwFolderInstalled(false);
+            pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+        }
+
+        if(chcpXmlConfig.isUseOfInitialVersionFromAssetsAllowed()) {
+            AssetsHelper.copyAssetDirectoryToAppDirectory(applicationContext.getAssets(), WWW_FOLDER, fileStructure.getWwwFolder());
+        } else {
+            String assetsRemoteZipUrl = chcpXmlConfig.getAssetsRemoteZipUrl();
+            if (TextUtils.isEmpty(assetsRemoteZipUrl)) {
+                AssetsHelper.createStubAppDirectory(fileStructure.getWwwFolder());
+            } else {
+                AssetsHelper.copyAssetsFromRemoteZipUrlToDirectory(chcpXmlConfig.getAssetsRemoteZipUrl(), fileStructure.getWwwFolder());
+            }
+        }
+    }
+
+    private boolean shouldAutoDownload() {
+        return chcpXmlConfig.isAutoDownloadIsAllowed();
+    }
+
+    private boolean shouldAutoInstall() {
+        if(!chcpXmlConfig.isAutoInstallIsAllowed()) {
+            return false;
+        }
+
+        final PluginFilesStructure readyForInstallationReleaseVersionFileStructure =
+                new PluginFilesStructure(applicationContext, pluginInternalPrefs.getReadyForInstallationReleaseVersionName());
+        final ApplicationConfig appConfig = appConfigStorage.loadFromFolder(readyForInstallationReleaseVersionFileStructure.getDownloadFolder());
+        if (appConfig == null) {
+            return false;
+        }
+
+        final UpdateTime updateTime = appConfig.getContentConfig().getUpdateTime();
+        if ((updateTime != UpdateTime.ON_RESUME) && (updateTime != UpdateTime.NOW)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // endregion
+
+    // region Assets installation events
+
+    /**
+     * Listener for event that assets folder are now installed on the external storage.
+     * From that moment all content will be displayed from it.
+     *
+     * @param event event details
+     * @see AssetsInstalledEvent
+     * @see AssetsHelper
+     * @see EventBus
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(AssetsInstalledEvent event) {
+        Log.d("CHCP", "Assets installed");
+
+        // update stored application version
+        pluginInternalPrefs.setAppBuildVersion(VersionHelper.applicationVersionCode(applicationContext));
+        pluginInternalPrefs.setWwwFolderInstalled(true);
+        pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+
+        isReady = true;
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+
+        if (chcpXmlConfig.isAutoDownloadIsAllowed() &&
+            !UpdatesInstaller.isInstalling() &&
+            !UpdatesLoader.isExecuting()) {
+            fetchUpdate(false);
+        }
+    }
+
+    /**
+     * Listener for event that we failed to install assets folder on the external storage.
+     * If so - nothing we can do, plugin is not gonna work.
+     *
+     * @param event event details
+     * @see AssetsInstallationErrorEvent
+     * @see AssetsHelper
+     * @see EventBus
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(AssetsInstallationErrorEvent event) {
+        Log.d("CHCP", "Can't install assets on device. Continue to work with default bundle");
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    // endregion
+
+    // region Update download events
+
+    /**
+     * Listener for event that we failed to automatically download an update because it's not allowed by the configuration.
+     *
+     * @param event event details
+     * @see AutoDownloadNotAllowedErrorEvent
+     * @see EventBus
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(AutoDownloadNotAllowedErrorEvent event) {
+        Log.d("CHCP", "Auto download is not allowed");
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    /**
+     * Listener for the event that update is loaded and ready for the installation.
+     *
+     * @param event event information
+     * @see EventBus
+     * @see UpdateIsReadyToInstallEvent
+     * @see UpdatesLoader
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(UpdateIsReadyToInstallEvent event) {
+        final ContentConfig newContentConfig = event.applicationConfig().getContentConfig();
+        Log.d("CHCP", "Update is ready for installation: " + newContentConfig.getReleaseVersion());
+
+        pluginInternalPrefs.setReadyForInstallationReleaseVersionName(newContentConfig.getReleaseVersion());
+        pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+
+        // perform installation if allowed
+        if (chcpXmlConfig.isAutoInstallIsAllowed() &&
+            (newContentConfig.getUpdateTime() == UpdateTime.NOW)) {
+            installUpdate(false);
+        }
+    }
+
+    /**
+     * Listener for event that there is no update available at the moment.
+     * We are as fresh as possible.
+     *
+     * @param event event information
+     * @see EventBus
+     * @see NothingToUpdateEvent
+     * @see UpdatesLoader
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(NothingToUpdateEvent event) {
+        Log.d("CHCP", "Nothing to update");
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    /**
+     * Listener for event that some error has happened during the update download process.
+     *
+     * @param event event information
+     * @see EventBus
+     * @see UpdateDownloadErrorEvent
+     * @see UpdatesLoader
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(UpdateDownloadErrorEvent event) {
+        Log.d("CHCP", "Failed to update");
+
+        final ChcpError error = event.error();
+        if ((error == ChcpError.LOCAL_VERSION_OF_APPLICATION_CONFIG_NOT_FOUND) ||
+            (error == ChcpError.LOCAL_VERSION_OF_MANIFEST_NOT_FOUND)) {
+            Log.d("CHCP", "Can't load application config from installation folder. Reinstalling external folder");
+            installWwwFolder();
+        }
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+
+        rollbackIfCorrupted(event.error());
+    }
+
+    // endregion
+
+    // region Update installation events
+
+    /**
+     * Listener for event that we failed to automatically install an update because it's not allowed by the configuration.
+     *
+     * @param event event details
+     * @see AutoInstallNotAllowedErrorEvent
+     * @see EventBus
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(AutoInstallNotAllowedErrorEvent event) {
+        Log.d("CHCP", "Auto install is not allowed");
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    /**
+     * Listener for event that we successfully installed new update.
+     *
+     * @param event event information
+     * @see EventBus
+     * @see UpdateInstalledEvent
+     * @see UpdatesInstaller
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(UpdateInstalledEvent event) {
+        Log.d("CHCP", "Update is installed");
+
+        final ContentConfig newContentConfig = event.applicationConfig().getContentConfig();
+
+        // update preferences
+        pluginInternalPrefs.setPreviousReleaseVersionName(pluginInternalPrefs.getCurrentReleaseVersionName());
+        pluginInternalPrefs.setCurrentReleaseVersionName(newContentConfig.getReleaseVersion());
+        pluginInternalPrefs.setReadyForInstallationReleaseVersionName("");
+        pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+
+        fileStructure = new PluginFilesStructure(applicationContext, newContentConfig.getReleaseVersion());
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    /**
+     * Listener for event that some error happened during the update installation.
+     *
+     * @param event event information
+     * @see UpdateInstallationErrorEvent
+     * @see EventBus
+     * @see UpdatesInstaller
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(UpdateInstallationErrorEvent event) {
+        Log.d("CHCP", "Failed to install. Error: " + event.error().getErrorDescription());
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+
+        rollbackIfCorrupted(event.error());
+    }
+
+    /**
+     * Listener for event that there is nothing to install.
+     *
+     * @param event event information
+     * @see NothingToInstallEvent
+     * @see UpdatesInstaller
+     * @see EventBus
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(NothingToInstallEvent event) {
+        Log.d("CHCP", "Nothing to install");
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    /**
+     * Listener for event that a rollback has been performed.
+     *
+     * @param event event information
+     * @see RollbackPerformedEvent
+     * @see EventBus
+     */
+    @SuppressWarnings("unused")
+    @Subscribe
+    public void onEvent(RollbackPerformedEvent event) {
+        Log.d("CHCP", "Rollback performed");
+
+        synchronized (EVENT_LISTENERS_LOCK) {
+            for (IHotCodePushEventListener listener : eventListeners) {
+                listener.onEvent(event);
+            }
+        }
+    }
+
+    // endregion
+
+    // region Rollback process
+
+    /**
+     * Rollback to the previous/bundle version, if this is needed.
+     *
+     * @param error error, based on which we will decide
+     */
+    private void rollbackIfCorrupted(ChcpError error) {
+        if ((error != ChcpError.LOCAL_VERSION_OF_APPLICATION_CONFIG_NOT_FOUND) &&
+            (error != ChcpError.LOCAL_VERSION_OF_MANIFEST_NOT_FOUND)) {
+            return;
+        }
+
+        if (pluginInternalPrefs.getPreviousReleaseVersionName().length() > 0) {
+            Log.d("CHCP", "Current release is corrupted, trying to rollback to the previous one");
+            rollbackToPreviousRelease();
+        } else {
+            Log.d("CHCP", "Current release is corrupted, reinstalling www folder from assets");
+            installWwwFolder();
+        }
+    }
+
+    /**
+     * Rollback to the previously installed version of the web content.
+     */
+    private void rollbackToPreviousRelease() {
+        pluginInternalPrefs.setCurrentReleaseVersionName(pluginInternalPrefs.getPreviousReleaseVersionName());
+        pluginInternalPrefs.setPreviousReleaseVersionName("");
+        pluginInternalPrefs.setReadyForInstallationReleaseVersionName("");
+        pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+
+        fileStructure.switchToRelease(pluginInternalPrefs.getCurrentReleaseVersionName());
+
+        EventBus.getDefault().post(new RollbackPerformedEvent());
+    }
+
+    // endregion
+}

--- a/src/android/src/com/nordnetab/chcp/main/core/IHotCodePushEventListener.java
+++ b/src/android/src/com/nordnetab/chcp/main/core/IHotCodePushEventListener.java
@@ -1,0 +1,40 @@
+package com.nordnetab.chcp.main.core;
+
+import com.nordnetab.chcp.main.events.AssetsInstallationErrorEvent;
+import com.nordnetab.chcp.main.events.AssetsInstalledEvent;
+import com.nordnetab.chcp.main.events.AutoDownloadNotAllowedErrorEvent;
+import com.nordnetab.chcp.main.events.AutoInstallNotAllowedErrorEvent;
+import com.nordnetab.chcp.main.events.NothingToInstallEvent;
+import com.nordnetab.chcp.main.events.NothingToUpdateEvent;
+import com.nordnetab.chcp.main.events.RollbackPerformedEvent;
+import com.nordnetab.chcp.main.events.UpdateDownloadErrorEvent;
+import com.nordnetab.chcp.main.events.UpdateInstallationErrorEvent;
+import com.nordnetab.chcp.main.events.UpdateInstalledEvent;
+import com.nordnetab.chcp.main.events.UpdateIsReadyToInstallEvent;
+
+/**
+ * Created by orarnon on 29/02/2016.
+ */
+public interface IHotCodePushEventListener {
+    void onEvent(AssetsInstalledEvent event);
+
+    void onEvent(AssetsInstallationErrorEvent event);
+
+    void onEvent(AutoDownloadNotAllowedErrorEvent event);
+
+    void onEvent(UpdateIsReadyToInstallEvent event);
+
+    void onEvent(NothingToUpdateEvent event);
+
+    void onEvent(UpdateDownloadErrorEvent event);
+
+    void onEvent(AutoInstallNotAllowedErrorEvent event);
+
+    void onEvent(UpdateInstalledEvent event);
+
+    void onEvent(UpdateInstallationErrorEvent event);
+
+    void onEvent(NothingToInstallEvent event);
+
+    void onEvent(RollbackPerformedEvent event);
+}

--- a/src/android/src/com/nordnetab/chcp/main/events/AutoDownloadNotAllowedErrorEvent.java
+++ b/src/android/src/com/nordnetab/chcp/main/events/AutoDownloadNotAllowedErrorEvent.java
@@ -1,0 +1,21 @@
+package com.nordnetab.chcp.main.events;
+
+import com.nordnetab.chcp.main.model.ChcpError;
+
+/**
+ * Created by Or Arnon on 07.03.16.
+ * <p/>
+ * Event is send when an auto download is initiated but according to the config it is not allowed.
+ */
+public class AutoDownloadNotAllowedErrorEvent extends PluginEventImpl {
+
+    public static final String EVENT_NAME = "chcp_autoUpdateLoadNotAllowed";
+
+    /**
+     * Class constructor.
+     *
+     */
+    public AutoDownloadNotAllowedErrorEvent() {
+        super(EVENT_NAME, ChcpError.AUTO_UPDATE_IS_NOT_ALLOWED);
+    }
+}

--- a/src/android/src/com/nordnetab/chcp/main/events/AutoInstallNotAllowedErrorEvent.java
+++ b/src/android/src/com/nordnetab/chcp/main/events/AutoInstallNotAllowedErrorEvent.java
@@ -1,0 +1,21 @@
+package com.nordnetab.chcp.main.events;
+
+import com.nordnetab.chcp.main.model.ChcpError;
+
+/**
+ * Created by Or Arnon on 07.03.16.
+ * <p/>
+ * Event is send when an auto install is initiated but according to the config it is not allowed.
+ */
+public class AutoInstallNotAllowedErrorEvent extends PluginEventImpl {
+
+    public static final String EVENT_NAME = "chcp_autoUpdateInstallNotAllowed";
+
+    /**
+     * Class constructor.
+     *
+     */
+    public AutoInstallNotAllowedErrorEvent() {
+        super(EVENT_NAME, ChcpError.AUTO_INSTALL_IS_NOT_ALLOWED);
+    }
+}

--- a/src/android/src/com/nordnetab/chcp/main/events/PluginEventImpl.java
+++ b/src/android/src/com/nordnetab/chcp/main/events/PluginEventImpl.java
@@ -12,7 +12,7 @@ import java.util.Map;
  * Also, base class for all plugin specific events.
  * All events are dispatched and captured through EventBus.
  *
- * @see de.greenrobot.event.EventBus
+ * @see org.greenrobot.eventbus.EventBus
  */
 class PluginEventImpl implements IPluginEvent {
 

--- a/src/android/src/com/nordnetab/chcp/main/events/RollbackPerformedEvent.java
+++ b/src/android/src/com/nordnetab/chcp/main/events/RollbackPerformedEvent.java
@@ -1,0 +1,18 @@
+package com.nordnetab.chcp.main.events;
+
+/**
+ * Created by Or Arnon on 01.03.16.
+ * <p/>
+ * Event is sent when a rollback has been performed.
+ */
+public class RollbackPerformedEvent extends PluginEventImpl {
+
+    public static final String EVENT_NAME = "chcp_rollbackPerformed";
+
+    /**
+     * Class constructor
+     */
+    public RollbackPerformedEvent() {
+        super(EVENT_NAME, null);
+    }
+}

--- a/src/android/src/com/nordnetab/chcp/main/model/ChcpError.java
+++ b/src/android/src/com/nordnetab/chcp/main/model/ChcpError.java
@@ -35,7 +35,9 @@ public enum ChcpError {
     // region Kind of warnings
 
     NOTHING_TO_INSTALL(1, "Nothing to install"),
-    NOTHING_TO_UPDATE(2, "Nothing new to load from server");
+    NOTHING_TO_UPDATE(2, "Nothing new to load from server"),
+    AUTO_UPDATE_IS_NOT_ALLOWED(3, "Auto update is not allowed"),
+    AUTO_INSTALL_IS_NOT_ALLOWED(4, "Auto install is not allowed");
 
     // endregion
 

--- a/src/android/src/com/nordnetab/chcp/main/network/JsonDownloader.java
+++ b/src/android/src/com/nordnetab/chcp/main/network/JsonDownloader.java
@@ -7,6 +7,8 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 
+import javax.net.ssl.HttpsURLConnection;
+
 /**
  * Created by Nikolay Demyankov on 22.07.15.
  * <p/>
@@ -66,6 +68,10 @@ abstract class JsonDownloader<T> {
         if (url == null) {
             throw new Exception("Invalid url format:" + downloadUrl);
         }
+
+        // don't use SSLv3 to download files
+        // see https://code.google.com/p/android/issues/detail?id=78187
+        HttpsURLConnection.setDefaultSSLSocketFactory(new NoSSLv3Factory());
 
         URLConnection urlConnection = url.openConnection();
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));

--- a/src/android/src/com/nordnetab/chcp/main/network/NoSSLv3Factory.java
+++ b/src/android/src/com/nordnetab/chcp/main/network/NoSSLv3Factory.java
@@ -1,0 +1,435 @@
+package com.nordnetab.chcp.main.network;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * {@link javax.net.ssl.SSLSocketFactory} that doesn't allow {@code SSLv3} only connections
+ * <p>fixes https://github.com/koush/ion/issues/386</p>
+ *
+ * <p> see https://code.google.com/p/android/issues/detail?id=78187 </p>
+ */
+public class NoSSLv3Factory extends SSLSocketFactory {
+    private final SSLSocketFactory delegate;
+
+    public NoSSLv3Factory() {
+        this.delegate = HttpsURLConnection.getDefaultSSLSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    private static Socket makeSocketSafe(Socket socket) {
+        if (socket instanceof SSLSocket && !(socket instanceof NoSSLv3SSLSocket)) {
+            socket = new NoSSLv3SSLSocket((SSLSocket) socket);
+        }
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return makeSocketSafe(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return makeSocketSafe(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return makeSocketSafe(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return makeSocketSafe(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return makeSocketSafe(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    /**
+     * Created by robUx4 on 25/10/2014.
+     */
+    private static class DelegateSSLSocket extends SSLSocket {
+
+        protected final SSLSocket delegate;
+
+        DelegateSSLSocket(SSLSocket delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public String[] getEnabledCipherSuites() {
+            return delegate.getEnabledCipherSuites();
+        }
+
+        @Override
+        public void setEnabledCipherSuites(String[] suites) {
+            delegate.setEnabledCipherSuites(suites);
+        }
+
+        @Override
+        public String[] getSupportedProtocols() {
+            return delegate.getSupportedProtocols();
+        }
+
+        @Override
+        public String[] getEnabledProtocols() {
+            return delegate.getEnabledProtocols();
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] protocols) {
+            delegate.setEnabledProtocols(protocols);
+        }
+
+        @Override
+        public SSLSession getSession() {
+            return delegate.getSession();
+        }
+
+        @Override
+        public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
+            delegate.addHandshakeCompletedListener(listener);
+        }
+
+        @Override
+        public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
+            delegate.removeHandshakeCompletedListener(listener);
+        }
+
+        @Override
+        public void startHandshake() throws IOException {
+            delegate.startHandshake();
+        }
+
+        @Override
+        public void setUseClientMode(boolean mode) {
+            delegate.setUseClientMode(mode);
+        }
+
+        @Override
+        public boolean getUseClientMode() {
+            return delegate.getUseClientMode();
+        }
+
+        @Override
+        public void setNeedClientAuth(boolean need) {
+            delegate.setNeedClientAuth(need);
+        }
+
+        @Override
+        public void setWantClientAuth(boolean want) {
+            delegate.setWantClientAuth(want);
+        }
+
+        @Override
+        public boolean getNeedClientAuth() {
+            return delegate.getNeedClientAuth();
+        }
+
+        @Override
+        public boolean getWantClientAuth() {
+            return delegate.getWantClientAuth();
+        }
+
+        @Override
+        public void setEnableSessionCreation(boolean flag) {
+            delegate.setEnableSessionCreation(flag);
+        }
+
+        @Override
+        public boolean getEnableSessionCreation() {
+            return delegate.getEnableSessionCreation();
+        }
+
+        @Override
+        public void bind(SocketAddress localAddr) throws IOException {
+            delegate.bind(localAddr);
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void connect(SocketAddress remoteAddr) throws IOException {
+            delegate.connect(remoteAddr);
+        }
+
+        @Override
+        public void connect(SocketAddress remoteAddr, int timeout) throws IOException {
+            delegate.connect(remoteAddr, timeout);
+        }
+
+        @Override
+        public SocketChannel getChannel() {
+            return delegate.getChannel();
+        }
+
+        @Override
+        public InetAddress getInetAddress() {
+            return delegate.getInetAddress();
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return delegate.getInputStream();
+        }
+
+        @Override
+        public boolean getKeepAlive() throws SocketException {
+            return delegate.getKeepAlive();
+        }
+
+        @Override
+        public InetAddress getLocalAddress() {
+            return delegate.getLocalAddress();
+        }
+
+        @Override
+        public int getLocalPort() {
+            return delegate.getLocalPort();
+        }
+
+        @Override
+        public SocketAddress getLocalSocketAddress() {
+            return delegate.getLocalSocketAddress();
+        }
+
+        @Override
+        public boolean getOOBInline() throws SocketException {
+            return delegate.getOOBInline();
+        }
+
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return delegate.getOutputStream();
+        }
+
+        @Override
+        public int getPort() {
+            return delegate.getPort();
+        }
+
+        @Override
+        public synchronized int getReceiveBufferSize() throws SocketException {
+            return delegate.getReceiveBufferSize();
+        }
+
+        @Override
+        public SocketAddress getRemoteSocketAddress() {
+            return delegate.getRemoteSocketAddress();
+        }
+
+        @Override
+        public boolean getReuseAddress() throws SocketException {
+            return delegate.getReuseAddress();
+        }
+
+        @Override
+        public synchronized int getSendBufferSize() throws SocketException {
+            return delegate.getSendBufferSize();
+        }
+
+        @Override
+        public int getSoLinger() throws SocketException {
+            return delegate.getSoLinger();
+        }
+
+        @Override
+        public synchronized int getSoTimeout() throws SocketException {
+            return delegate.getSoTimeout();
+        }
+
+        @Override
+        public boolean getTcpNoDelay() throws SocketException {
+            return delegate.getTcpNoDelay();
+        }
+
+        @Override
+        public int getTrafficClass() throws SocketException {
+            return delegate.getTrafficClass();
+        }
+
+        @Override
+        public boolean isBound() {
+            return delegate.isBound();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public boolean isConnected() {
+            return delegate.isConnected();
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return delegate.isInputShutdown();
+        }
+
+        @Override
+        public boolean isOutputShutdown() {
+            return delegate.isOutputShutdown();
+        }
+
+        @Override
+        public void sendUrgentData(int value) throws IOException {
+            delegate.sendUrgentData(value);
+        }
+
+        @Override
+        public void setKeepAlive(boolean keepAlive) throws SocketException {
+            delegate.setKeepAlive(keepAlive);
+        }
+
+        @Override
+        public void setOOBInline(boolean oobinline) throws SocketException {
+            delegate.setOOBInline(oobinline);
+        }
+
+        @Override
+        public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+            delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
+        }
+
+        @Override
+        public synchronized void setReceiveBufferSize(int size) throws SocketException {
+            delegate.setReceiveBufferSize(size);
+        }
+
+        @Override
+        public void setReuseAddress(boolean reuse) throws SocketException {
+            delegate.setReuseAddress(reuse);
+        }
+
+        @Override
+        public synchronized void setSendBufferSize(int size) throws SocketException {
+            delegate.setSendBufferSize(size);
+        }
+
+        @Override
+        public void setSoLinger(boolean on, int timeout) throws SocketException {
+            delegate.setSoLinger(on, timeout);
+        }
+
+        @Override
+        public synchronized void setSoTimeout(int timeout) throws SocketException {
+            delegate.setSoTimeout(timeout);
+        }
+
+        @Override
+        public void setSSLParameters(SSLParameters p) {
+            delegate.setSSLParameters(p);
+        }
+
+        @Override
+        public void setTcpNoDelay(boolean on) throws SocketException {
+            delegate.setTcpNoDelay(on);
+        }
+
+        @Override
+        public void setTrafficClass(int value) throws SocketException {
+            delegate.setTrafficClass(value);
+        }
+
+        @Override
+        public void shutdownInput() throws IOException {
+            delegate.shutdownInput();
+        }
+
+        @Override
+        public void shutdownOutput() throws IOException {
+            delegate.shutdownOutput();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return delegate.equals(o);
+        }
+    }
+
+    /**
+     * An {@link javax.net.ssl.SSLSocket} that doesn't allow {@code SSLv3} only connections
+     * <p>fixes https://github.com/koush/ion/issues/386</p>
+     */
+    private static class NoSSLv3SSLSocket extends DelegateSSLSocket {
+
+        private NoSSLv3SSLSocket(SSLSocket delegate) {
+            super(delegate);
+
+            String canonicalName = delegate.getClass().getCanonicalName();
+            if (!canonicalName.equals("org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl")) {
+                // try replicate the code from HttpConnection.setupSecureSocket()
+                try {
+                    Method msetUseSessionTickets = delegate.getClass().getMethod("setUseSessionTickets", boolean.class);
+                    if (null != msetUseSessionTickets) {
+                        msetUseSessionTickets.invoke(delegate, true);
+                    }
+                } catch (NoSuchMethodException ignored) {
+                } catch (InvocationTargetException ignored) {
+                } catch (IllegalAccessException ignored) {
+                }
+            }
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] protocols) {
+            if (protocols != null && protocols.length == 1 && "SSLv3".equals(protocols[0])) {
+                // no way jose
+                // see issue https://code.google.com/p/android/issues/detail?id=78187
+                List<String> enabledProtocols = new ArrayList<String>(Arrays.asList(delegate.getEnabledProtocols()));
+                if (enabledProtocols.size() > 1) {
+                    enabledProtocols.remove("SSLv3");
+                }
+                protocols = enabledProtocols.toArray(new String[enabledProtocols.size()]);
+            }
+            super.setEnabledProtocols(protocols);
+        }
+    }
+
+}

--- a/src/android/src/com/nordnetab/chcp/main/updater/UpdateLoaderWorker.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/UpdateLoaderWorker.java
@@ -224,7 +224,7 @@ class UpdateLoaderWorker implements WorkerTask {
         boolean isFinishedWithSuccess = true;
         try {
             FileDownloader.downloadFiles(filesStructure.getDownloadFolder(), contentUrl, downloadFiles);
-        } catch (IOException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             isFinishedWithSuccess = false;
         }

--- a/src/android/src/com/nordnetab/chcp/main/updater/UpdatesInstaller.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/UpdatesInstaller.java
@@ -9,7 +9,7 @@ import com.nordnetab.chcp.main.model.PluginFilesStructure;
 
 import java.io.File;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 
 /**
  * Created by Nikolay Demyankov on 22.07.15.

--- a/src/android/src/com/nordnetab/chcp/main/updater/UpdatesLoader.java
+++ b/src/android/src/com/nordnetab/chcp/main/updater/UpdatesLoader.java
@@ -4,7 +4,7 @@ import android.content.Context;
 
 import com.nordnetab.chcp.main.model.ChcpError;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 
 /**
  * Created by Nikolay Demyankov on 24.07.15.

--- a/src/android/src/com/nordnetab/chcp/main/utils/AssetsHelper.java
+++ b/src/android/src/com/nordnetab/chcp/main/utils/AssetsHelper.java
@@ -1,16 +1,29 @@
 package com.nordnetab.chcp.main.utils;
 
 import android.content.res.AssetManager;
+import android.util.Log;
+import android.webkit.URLUtil;
 
+import com.nordnetab.chcp.main.config.ContentConfig;
 import com.nordnetab.chcp.main.events.AssetsInstallationErrorEvent;
 import com.nordnetab.chcp.main.events.AssetsInstalledEvent;
+import com.nordnetab.chcp.main.model.PluginFilesStructure;
+import com.nordnetab.chcp.main.network.FileDownloader;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 
 /**
  * Created by Nikolay Demyankov on 21.07.15.
@@ -18,10 +31,93 @@ import de.greenrobot.event.EventBus;
  * Utility class to copy files from assets folder into the external storage.
  */
 public class AssetsHelper {
+    private static final int ZIP_BUFFER_SIZE = 1024 * 4;
 
     private static boolean isWorking;
 
     private AssetsHelper() {
+    }
+
+    public static void copyAssetsFromRemoteZipUrlToDirectory(final String assetsRemoteZipUrl, final String toDirectory) {
+        if (isWorking) {
+            return;
+        }
+
+        isWorking = true;
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                long startTime;
+                long elapsed;
+
+                try {
+                    recreateCacheFolder(toDirectory);
+
+                    File assetsDestinationDirectory = new File(toDirectory);
+
+                    String remoteFilePath = URLUtil.guessFileName(assetsRemoteZipUrl, null, null);
+
+                    String assetsLocalZipFilePath = Paths.get(assetsDestinationDirectory.getParent(), remoteFilePath);
+
+                    startTime = System.currentTimeMillis();
+                    FileDownloader.download(assetsRemoteZipUrl, assetsLocalZipFilePath, null);
+                    elapsed = System.currentTimeMillis() - startTime;
+                    Log.d("CHCP", String.format("Downloading remote assets zip file took %d ms", elapsed));
+
+                    startTime = System.currentTimeMillis();
+                    extractZipFile(assetsLocalZipFilePath, toDirectory);
+                    elapsed = System.currentTimeMillis() - startTime;
+                    Log.d("CHCP", String.format("Extracting remote assets zip file took %d ms", elapsed));
+
+                    FilesUtility.delete(assetsLocalZipFilePath);
+
+                    isWorking = false;
+
+                    EventBus.getDefault().post(new AssetsInstalledEvent());
+                } catch(IOException exception) {
+                    isWorking = false;
+
+                    // fallback
+                    createStubAppDirectory(toDirectory);
+                }
+            }
+        }).start();
+    }
+
+    /**
+     * Copy files from the assets folder into the specific folder on the external storage.
+     * Method runs asynchronously. Results are dispatched through events.
+     *
+     * @param toDirectory   absolute path to the destination folder on the external storage
+     *
+     * @see AssetsInstallationErrorEvent
+     * @see AssetsInstalledEvent
+     * @see EventBus
+     */
+    public static void createStubAppDirectory(final String toDirectory) {
+        if (isWorking) {
+            return;
+        }
+
+        isWorking = true;
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                recreateCacheFolder(toDirectory);
+
+                if(createStubApplicationConfiguration(toDirectory) &&
+                   createStubContentManifest(toDirectory)) {
+                    EventBus.getDefault().post(new AssetsInstalledEvent());
+                } else {
+                    EventBus.getDefault().post(new AssetsInstallationErrorEvent());
+                }
+
+                isWorking = false;
+
+            }
+        }).start();
     }
 
     /**
@@ -58,10 +154,13 @@ public class AssetsHelper {
         }).start();
     }
 
+    private static void recreateCacheFolder(String directory) {
+        FilesUtility.delete(directory);
+        FilesUtility.ensureDirectoryExists(directory);
+    }
+
     private static void copyAssetDirectory(AssetManager assetManager, String fromDirectory, String toDirectory) throws IOException {
-        // recreate cache folder
-        FilesUtility.delete(toDirectory);
-        FilesUtility.ensureDirectoryExists(toDirectory);
+        recreateCacheFolder(toDirectory);
 
         // copy files
         String[] files = assetManager.list(fromDirectory);
@@ -94,5 +193,81 @@ public class AssetsHelper {
 
         in.close();
         out.close();
+    }
+
+    private static void extractZipFile(String assetsZipFilePath, String toDirectory) throws IOException {
+        ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(assetsZipFilePath));
+
+        try {
+            ZipEntry zipEntry;
+
+            while((zipEntry = zipInputStream.getNextEntry()) != null) {
+                File extractedFile = new File(toDirectory, zipEntry.getName());
+                if(zipEntry.isDirectory()) {
+                    if(!extractedFile.isDirectory() && !extractedFile.mkdirs()) {
+                        throw new IOException("Failed to create directory");
+                    }
+                } else {
+                    byte[] buffer = new byte[ZIP_BUFFER_SIZE];
+                    FileOutputStream fileOutputStream = new FileOutputStream(extractedFile, false);
+                    BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream, buffer.length);
+
+                    int bytesRead;
+                    try {
+                        while((bytesRead = zipInputStream.read(buffer, 0, buffer.length)) != -1) {
+                            bufferedOutputStream.write(buffer, 0, bytesRead);
+                        }
+                    } finally {
+                        bufferedOutputStream.flush();
+                        bufferedOutputStream.close();
+
+                        fileOutputStream.flush();
+                        fileOutputStream.close();
+
+                        zipInputStream.closeEntry();
+                    }
+                }
+            }
+        } finally {
+            zipInputStream.close();
+        }
+    }
+
+    private static boolean saveJsonObjectToFile(JSONObject jsonObject, File file) {
+        try {
+            FilesUtility.ensureDirectoryExists(file.getParent());
+
+            FileOutputStream outputStream = new FileOutputStream(file, false);
+
+            outputStream.write(jsonObject.toString().getBytes());
+
+            outputStream.close();
+
+            return true;
+        } catch (IOException ex) {
+            Log.d("CHCP", "Could not create an empty JSON file", ex);
+            return false;
+        }
+    }
+
+    private static boolean createStubApplicationConfiguration(String outputDirectory) {
+        File configurationFile = new File(outputDirectory, PluginFilesStructure.CONFIG_FILE_NAME);
+        JSONObject configuration = new JSONObject();
+
+        try {
+            configuration.put(ContentConfig.JsonKeys.VERSION, "");
+            configuration.put(ContentConfig.JsonKeys.CONTENT_URL, "");
+        } catch(JSONException e) {
+            return false;
+        }
+
+        return saveJsonObjectToFile(configuration, configurationFile);
+    }
+
+    private static boolean createStubContentManifest(String outputDirectory) {
+        File manifestFile = new File(outputDirectory, PluginFilesStructure.MANIFEST_FILE_NAME);
+        JSONObject manifest = new JSONObject();
+
+        return saveJsonObjectToFile(manifest, manifestFile);
     }
 }


### PR DESCRIPTION
1. refactored plugin to support more than one concurrently active cordova activity
2. added support for concurrent file download
3. updated event bus to latest release version (3.0.0)
4. added plugin configuration keys
   a. auto-redirect-to-local-storage-index-page - if enabled, the index.html page will be loaded after web app updates / rollbacks / etc. otherwise not reload would take place. default: enabled.
   b. require-fresh-install-after-app-update - if enabled, a fresh installed will be performed when the hosting app is updated. otherwise, the existing web app code will be used and updates will be made from that version on. default: enabled.
   c. file-download-concurrency - the number of files that will be downloaded concurrently when an update is performed. default: 1.
   d. use-initial-version-from-assets - if enabled, the default assets will be taken from the assets that were delivered with the hosting application. otherwise, either the assets will be downloaded as a zip file from a remote URL (see configuration key below), or a stub update configuration will be created, therefore triggering a download of ALL of the update files.
   e. assets-remote-zip-url - if set, along with the "use-initial-version-from-assets" configuration key, will determine where the zipped assets will be downloaded from
5. added new warnings to ChcpError
   a. AUTO_UPDATE_IS_NOT_ALLOWED
   b. AUTO_INSTALL_IS_NOT_ALLOWED
